### PR TITLE
Replace guid assembly references with named references

### DIFF
--- a/Examples/YamlDotNet.Examples.asmdef
+++ b/Examples/YamlDotNet.Examples.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "YamlDotNet.Examples",
     "references": [
-        "guid:b3f49edfedc855a48aa1a9e5d3cba438"
+        "YamlDotNetUser"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
because older Unity supports only named references